### PR TITLE
Update README.md with alternative Docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Set ADMIN_EMAIL and ADMIN_SLUG in deploy/docker-compose.dev.yml. These are the o
 1. Execute the following commands from the deploy folder:
     ```
     docker-compose -f docker-compose.dev.yml up
+    ```   
+   If you receive an error message (`/buildx_buildkit_buildxbuilder0 is already in use`), use this command instead:
+    ```
+    BUILDKIT=1 docker compose -f docker-compose.dev.yml up
     ```
 2. Visit localhost:9000 to login and start writing
 3. If you set your slug and publish any articles, you can view them at localhost:9222?domain=<admin slug>


### PR DESCRIPTION
Buildkit is not necessarily enabled in Docker installs; specify the `BUILDKIT=1` flag if an error is encountered.