### PR TITLE
Fix/notes cache and slug

### DIFF
--- a/tasks/logic/notes.js
+++ b/tasks/logic/notes.js
@@ -268,6 +268,8 @@ END`;
     if (tags) {
         await pool.query(`UPDATE btw.notes SET tags = $1 WHERE id = $2 AND user_id = $3`, [tags, id, user_id]);
     }
+
+    noteCacheHelper(user_id);
 }
 
 async function getNotes({ user_id, page, limit, after = 0 }) {

--- a/tasks/logic/notes.js
+++ b/tasks/logic/notes.js
@@ -428,10 +428,13 @@ async function publishNote({ user_id, id }) {
 
     const note = rows[0];
 
-    const slug = note.title
-        .toLowerCase()
-        .replace(/ /g, "-")
-        .replace(/[^\w-]+/g, "");
+    let slug = note.slug;
+    if (!slug) {
+        slug = note.title
+            .toLowerCase()
+            .replace(/ /g, "-")
+            .replace(/[^\w-]+/g, "");
+    }
 
     const html = note.html || "";
     let image = "";


### PR DESCRIPTION
fix: ensure content updates are published and slugs are preserved

- Fix issue where updated notes were not reflected on the published site
  - Cause: missing cache invalidation
  - Fix: added noteCacheHelper(user_id) call after upsertNote

- Fix issue where URL slug changed on unpublish/republish
  - Cause: publishNote always regenerated slug
  - Fix: reuse existing slug if present
