### PR TITLE
Fix pm2 instace naming for list service

### DIFF
--- a/list/pm2-dev.json
+++ b/list/pm2-dev.json
@@ -1,7 +1,7 @@
 {
   "apps": [
     {
-      "name": "writer",
+      "name": "list",
       "script": "npm",
       "args": ["run", "start"]
     }

--- a/list/pm2-prod.json
+++ b/list/pm2-prod.json
@@ -1,7 +1,7 @@
 {
   "apps": [
     {
-      "name": "writer",
+      "name": "list",
       "script": "npm",
       "args": ["run", "build:serve"]
     }


### PR DESCRIPTION
I was navigating the list's service logs and I saw the pm2 instance showing writer instead of list, I got confused for a sec

<img width="965" height="706" alt="image" src="https://github.com/user-attachments/assets/18069d22-1845-4172-9a6b-cf8cc0bc7f22" />
 